### PR TITLE
Screenshot foreground color

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The colors you list will always be used, no matter which coloring approach is se
 
 It is also good to note that the frontmatter only works for that markdown it is in. If you open another Markdown file without frontmatter, the settings from settings tab will be used.
 
+More than the default frontmatter options, it also supports another option (and may be upcomming more options):
+
+**screenshotFgColor:** Is an option that allows you to set the foreground color of the screenshot. It accepts any valid CSS color (hex, color name, rgb, rgba and hsl). It's nice to remember that this color is applied to foreground only. Not to using it.
+
 ### Inline Markmap
 
 You can also use the inline markmap syntax to create a mindmap in your note. You must create a ` ```markmap ` code

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It is also good to note that the frontmatter only works for that markdown it is 
 
 More than the default frontmatter options, it also supports another option (and may be upcomming more options):
 
-**screenshotFgColor:** Is an option that allows you to set the foreground color of the screenshot. It accepts any valid CSS color (hex, color name, rgb, rgba and hsl). It's nice to remember that this color is applied to foreground only. Not to using it.
+**screenshotFgColor:** Is an option that allows you to set the foreground color of the screenshot. It accepts any valid CSS color (hex, color name, rgb, rgba and hsl). It's nice to remember that this color is applied to screenshot only, and not while using the plugin.
 
 ### Inline Markmap
 

--- a/src/@types/models.d.ts
+++ b/src/@types/models.d.ts
@@ -1,0 +1,5 @@
+import { IMarkmapOptions } from "markmap-common";
+
+type FrontmatterOptions = Partial<IMarkmapOptions> & {
+  screenshotFgColor?: string;
+};

--- a/src/copy-image.ts
+++ b/src/copy-image.ts
@@ -9,11 +9,13 @@ export function copyImageToClipboard(
   currentMm: Markmap,
   frontmatterOptions: FrontmatterOptions
 ) {
-  console.log(frontmatterOptions);
-  const oldForeground = setForeground(
-    currentMm,
-    frontmatterOptions?.screenshotFgColor || settings.screenshotFgColor
-  );
+  let oldForeground: string;
+  if (!settings.screenshotTransparentBg) {
+    oldForeground = setForeground(
+      currentMm,
+      frontmatterOptions?.screenshotFgColor || settings.screenshotFgColor
+    );
+  }
   currentMm.fit().then(() => {
     d3SvgToPng("#markmap", "markmap.png", {
       scale: 3,
@@ -24,7 +26,9 @@ export function copyImageToClipboard(
         : settings.screenshotBgColor,
       quality: 1,
     }).then((output) => {
-      setForeground(currentMm, oldForeground);
+      if (!settings.screenshotTransparentBg) {
+        setForeground(currentMm, oldForeground);
+      }
       const blob = dataURItoBlob(output);
 
       navigator.clipboard

--- a/src/copy-image.ts
+++ b/src/copy-image.ts
@@ -10,12 +10,10 @@ export function copyImageToClipboard(
   frontmatterOptions: FrontmatterOptions
 ) {
   let oldForeground: string;
-  if (!settings.screenshotTransparentBg) {
-    oldForeground = setForeground(
-      currentMm,
-      frontmatterOptions?.screenshotFgColor || settings.screenshotFgColor
-    );
-  }
+  oldForeground = setForeground(
+    currentMm,
+    frontmatterOptions?.screenshotFgColor || settings.screenshotFgColor
+  );
   currentMm.fit().then(() => {
     d3SvgToPng("#markmap", "markmap.png", {
       scale: 3,
@@ -26,9 +24,8 @@ export function copyImageToClipboard(
         : settings.screenshotBgColor,
       quality: 1,
     }).then((output) => {
-      if (!settings.screenshotTransparentBg) {
-        setForeground(currentMm, oldForeground);
-      }
+      setForeground(currentMm, oldForeground);
+
       const blob = dataURItoBlob(output);
 
       navigator.clipboard

--- a/src/copy-image.ts
+++ b/src/copy-image.ts
@@ -7,6 +7,7 @@ export function copyImageToClipboard(
   settings: MindMapSettings,
   currentMm: Markmap
 ) {
+  const oldForeground = setForeground(currentMm, settings.screenshotFgColor);
   currentMm.fit().then(() => {
     d3SvgToPng("#markmap", "markmap.png", {
       scale: 3,
@@ -17,34 +18,54 @@ export function copyImageToClipboard(
         : settings.screenshotBgColor,
       quality: 1,
     }).then((output) => {
+      setForeground(currentMm, oldForeground);
       const blob = dataURItoBlob(output);
 
-      navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-      new Notice("Image copied to clipboard");
+      navigator.clipboard
+        .write([new ClipboardItem({ "image/png": blob })])
+        .then(() => {
+          new Notice("Image copied to clipboard");
+        });
     });
   });
 }
 
+function setForeground(currentMm: Markmap, foreground: string) {
+  const svg = currentMm.svg;
+
+  let oldForeground = svg.style("color");
+  svg
+    .node()
+    .querySelectorAll("div")
+    .forEach((div) => {
+      oldForeground = oldForeground || div.style.color;
+    });
+
+  svg.style("color", foreground);
+
+  svg
+    .node()
+    .querySelectorAll("div")
+    .forEach((div) => {
+      div.style.color = foreground;
+    });
+
+  return oldForeground;
+}
+
 function dataURItoBlob(dataURI: string) {
-  // convert base64 to raw binary data held in a string
-  // doesn't handle URLEncoded DataURIs - see SO answer #6850276 for code that does this
   var byteString = atob(dataURI.split(",")[1]);
 
-  // separate out the mime component
   var mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
 
-  // write the bytes of the string to an ArrayBuffer
   var ab = new ArrayBuffer(byteString.length);
 
-  // create a view into the buffer
   var ia = new Uint8Array(ab);
 
-  // set the bytes of the buffer to the correct values
   for (var i = 0; i < byteString.length; i++) {
     ia[i] = byteString.charCodeAt(i);
   }
 
-  // write the ArrayBuffer to a blob, and you're done
   var blob = new Blob([ab], { type: mimeString });
   return blob;
 }

--- a/src/copy-image.ts
+++ b/src/copy-image.ts
@@ -2,12 +2,18 @@ import { Notice } from "obsidian";
 import { MindMapSettings } from "./settings";
 import { Markmap } from "markmap-view";
 import d3SvgToPng from "d3-svg-to-png";
+import { FrontmatterOptions } from "./@types/models";
 
 export function copyImageToClipboard(
   settings: MindMapSettings,
-  currentMm: Markmap
+  currentMm: Markmap,
+  frontmatterOptions: FrontmatterOptions
 ) {
-  const oldForeground = setForeground(currentMm, settings.screenshotFgColor);
+  console.log(frontmatterOptions);
+  const oldForeground = setForeground(
+    currentMm,
+    frontmatterOptions?.screenshotFgColor || settings.screenshotFgColor
+  );
   currentMm.fit().then(() => {
     d3SvgToPng("#markmap", "markmap.png", {
       scale: 3,

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ export default class MindMap extends Plugin {
         animationDuration: 500,
         maxWidth: 0,
         screenshotBgColor: "#039614",
+        screenshotFgColor: "#ffffff",
         screenshotTransparentBg: true,
       },
       await this.loadData()

--- a/src/mindmap-view.ts
+++ b/src/mindmap-view.ts
@@ -17,6 +17,11 @@ import { createSVG, getComputedCss, removeExistingSVG } from "./markmap-svg";
 import { copyImageToClipboard } from "./copy-image";
 import { htmlEscapePlugin } from "./html-escape-plugin";
 import { MindMapSettings } from "./settings";
+import { FrontmatterOptions } from "./@types/models";
+
+type CustomFrontmatter = {
+  markmap: IMarkmapJSONOptions & { screenshotFgColor: string };
+};
 
 export default class MindmapView extends ItemView {
   filePath: string;
@@ -37,6 +42,7 @@ export default class MindmapView extends ItemView {
   markmapSVG: Markmap;
   transformer: Transformer;
   options: Partial<IMarkmapOptions>;
+  frontmatterOptions: FrontmatterOptions;
   hasFit: boolean;
 
   groupEventListenerFn: () => unknown;
@@ -68,7 +74,13 @@ export default class MindmapView extends ItemView {
         item
           .setIcon("image-file")
           .setTitle("Copy screenshot")
-          .onClick(() => copyImageToClipboard(this.settings, this.markmapSVG))
+          .onClick(() =>
+            copyImageToClipboard(
+              this.settings,
+              this.markmapSVG,
+              this.frontmatterOptions
+            )
+          )
       )
       .addSeparator()
       .addItem((item) =>
@@ -245,7 +257,13 @@ export default class MindmapView extends ItemView {
 
     let { root, scripts, styles, frontmatter } = await this.transformMarkdown();
 
+    const actualFrontmatter = frontmatter as CustomFrontmatter;
+
     const options = deriveOptions(frontmatter?.markmap);
+    this.frontmatterOptions = {
+      ...options,
+      screenshotFgColor: actualFrontmatter?.markmap?.screenshotFgColor,
+    };
 
     if (styles) loadCSS(styles);
     if (scripts) loadJS(scripts);

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,12 +1,5 @@
-import {
-  App,
-  PluginSettingTab,
-  Setting,
-  SliderComponent,
-  SplitDirection,
-} from "obsidian";
+import { App, PluginSettingTab, Setting, SplitDirection } from "obsidian";
 import MindMap from "./main";
-import { MindMapSettings } from "./settings";
 
 export class MindMapSettingsTab extends PluginSettingTab {
   plugin: MindMap;

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -285,6 +285,18 @@ export class MindMapSettingsTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName("Screenshot foreground color")
+      .setDesc("Foreground color for the screenshot")
+      .addColorPicker((colPicker) =>
+        colPicker
+          .setValue(this.plugin.settings.screenshotFgColor?.toString())
+          .onChange((value: string) => {
+            this.plugin.settings.screenshotFgColor = value;
+            save();
+          })
+      );
+
     // animation duration
     new Setting(containerEl)
       .setName("Animation duration")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,5 +30,6 @@ export class MindMapSettings {
   maxWidth: number = 0;
   // below a beautiful dark blue color
   screenshotBgColor: string = "#039614";
+  screenshotFgColor: string = "#ffffff";
   screenshotTransparentBg: boolean = true;
 }


### PR DESCRIPTION
**Issue: (#43) ** [link](https://github.com/AdrianSimionov/obsidian-mindmap-nextgen/issues/43)

**What has been done:***

- [x] I added settings to set the foreground color
- [x] I have added the functionality of setting it.
- [x] Add frontmatter options

** What to test? **

1. If the color blink is ok (I may find another way to implement it)
2. If the options work okay.

Obs. It is known that when there is the katex plugin, the screenshot does not work. I will take a look at that, but this would be another branch, another job.
